### PR TITLE
Posibility to use custom own url

### DIFF
--- a/src/services/S3SecureDownloadsService.php
+++ b/src/services/S3SecureDownloadsService.php
@@ -70,7 +70,12 @@ class S3SecureDownloadsService extends Component
 		$resource = str_replace( array( '%2F', '%2B' ), array( '/', '+' ), rawurlencode( $baseAssetPath ) );
 
 		$string_to_sign = "GET\n\n\n{$expires}\n/{$bucketName}/{$resource}";
-		$final_url = "https://{$bucketName}.s3.amazonaws.com/{$resource}?";
+		
+		if ($this->convertEnvVariable($assetSettings['hasUrls'])) {
+            		$final_url = "{$this->convertEnvVariable($assetSettings['url'])}/{$resource}?";
+		} else {
+			$final_url = "https://{$bucketName}.s3.amazonaws.com/{$resource}?";
+		}
 
 		$append_char = '?';
 		foreach ( $headers as $header => $value ) {


### PR DESCRIPTION
When using a `.` in the bucket url, the default SSL certificate doesn't work.
Using an custom url via cloudfront or just the full url like `https://s3-eu-west-1.amazonaws.com/bucketname.example.com` this problem is solved.