### PR TITLE
Aws endpoint

### DIFF
--- a/src/services/SignUrl.php
+++ b/src/services/SignUrl.php
@@ -7,6 +7,7 @@ use Aws\S3\S3Client;
 use Craft;
 use craft\base\Component;
 use craft\elements\Asset;
+use fortrabbit\ObjectStorage\Fs as FortrabbitFs;
 use kennethormandy\s3securedownloads\events\SignUrlEvent;
 use kennethormandy\s3securedownloads\S3SecureDownloads;
 use yii\base\Exception;
@@ -37,14 +38,19 @@ class SignUrl extends Component
 
         $region = Craft::parseEnv($volume->region);
 
+        // If we have a Fortrabbit Filesystem, pass-through the server endpoint to the AWS S3Client
+        // Null values for this setting are acceptable/the default (vendor/aws/aws-sdk-php/src/S3/S3Client.php @ line 423)
+        $volumeEndpoint = $volume instanceof FortrabbitFs ? Craft::parseEnv($volume->endpoint) : null;
+
         // TODO Use craftcms/aws-s3 helper function
         $client = new S3Client([
             'credentials' => [
-                        'key' => Craft::parseEnv($volume->keyId),
-                        'secret' => Craft::parseEnv($volume->secret),
-                ],
+                'key' => Craft::parseEnv($volume->keyId),
+                'secret' => Craft::parseEnv($volume->secret),
+            ],
             'region' => $region,
             'version' => 'latest',
+            'endpoint' => $volumeEndpoint
         ]);
 
         // TODO Right now the setting uses the old format (86400ms)

--- a/src/services/SignUrl.php
+++ b/src/services/SignUrl.php
@@ -45,9 +45,9 @@ class SignUrl extends Component
         // TODO Use craftcms/aws-s3 helper function
         $client = new S3Client([
             'credentials' => [
-                'key' => Craft::parseEnv($volume->keyId),
-                'secret' => Craft::parseEnv($volume->secret),
-            ],
+                        'key' => Craft::parseEnv($volume->keyId),
+                        'secret' => Craft::parseEnv($volume->secret),
+                ],
             'region' => $region,
             'version' => 'latest',
             'endpoint' => $volumeEndpoint


### PR DESCRIPTION
Minor change to support custom endpoints from the Fortrabbit Object Storage plugin.

We utilise Minio Object Storage for local development environments, with AWS S3 handling our production environments. We utilise the Fortrabbit Object Storage plugin to wrap the Craft AWS plugin, as this allows defining custom server endpoints for S3-alike Object Storage services.

This update simple checks to see if the FileSystem record is a Fortrabbit Fs class, and if so, passing through the defined endpoint value to the AWS S3Client, else passes NULL. The AWS S3Client class handles the endpoint as having a default value of null if not supplied.